### PR TITLE
Adding helm v3 signing feature change

### DIFF
--- a/helm-v3/000-helm-v3.md
+++ b/helm-v3/000-helm-v3.md
@@ -79,7 +79,7 @@ Other changes to commands are described in their relevant sections within this d
 4.  [Hooks](./004-hooks.md)
 5.  [Plugins](./005-plugins.md)
 6.  [Repositories](./006-repositories.md)
-7.  [Security Considerations](./007-security.md)
+7.  [Security](./007-security.md)
 8.  [Appendix A: A Helm Controller](./008-controller.md)
 9.  [Appendix B: What Is A Package Manager](./009-package_manager.md)
 10. [Appendix C: Removed Sections](010-removed.md)

--- a/helm-v3/007-security.md
+++ b/helm-v3/007-security.md
@@ -1,4 +1,18 @@
-# Security Considerations
+# Security
+
+## Chart Signing and Verification
+
+In Helm v3 signing and verification will be handled by an external application.
+By default this with be GnuPG and will work in a manner similar to Git. Users will
+be able to configure Helm to use other binaries and commands on the binary if
+they want.
+
+For reference, Helm v2 includes PGP handling and does not require an external
+tool to be present. GnuPG changing to a keybox format and the PGP handling not
+being able to support smart cards (e.g., Yubikey) have caused problems for some
+users.
+
+## Security Considerations
 
 This architecture for Helm is more secure than Helm 2 (and equally secure to
 Helm Classic). The following security goals are met by this proposal:


### PR DESCRIPTION
cc @bacongobbler @adamreese @technosophos 

I believe this will work on *nix and Windows (non-cygwin or subsystem for linux) without an issue. @bacongobbler would know better.

This would correct my need for the helm-gpg plugin and make supporting keybox files easier.