### PR TITLE
Adding list of different Helm project teams

### DIFF
--- a/Teams.md
+++ b/Teams.md
@@ -1,0 +1,41 @@
+# Teams
+
+Helm has various projects being run by different teams with different responsibilities. This document lists out the teams, their responsibilities, and how to contact them directly.
+
+Joining one of these teams is documented in the [governance](governance/governance.md) and with the respective projects within Helm.
+
+## Helm Org Maintainers
+
+The Org Maintainers are a team defined in the [governance](governance/governance.md). This is the high level set of maintainers responsible with the well being of Helm. Consider this a similar team to the Kubernetes Steering Committee.
+
+Repositories under the Helm organization not owned by another team, listed below, are owned by the Org Maintainers.
+
+This team can be directly contacted at the private address of cncf-helm-maintainers@lists.cncf.io. The members of this team are documented in the MAINTAINERS.md file in this repository.
+
+## Security Team
+
+Helm has a security team and process for handling all security issues. This team, the security process, and the method to contact them (including with the use of encryption) is documented in the SECURITY.md file.
+
+## Helm Client
+
+The [Helm client/CLI](https://github.com/helm/helm) has a dedicated team maintaining it. The members of that team are documented in the [OWNERS](https://github.com/helm/helm/blob/master/OWNERS) file in the root of the project.
+
+This team can be directly contacted at the private address of cncf-helm-core-maintainers@lists.cncf.io.
+
+## Charts Maintainers
+
+The Charts Maintainers handle numerous repositories in the Helm GitHub organization. Specifically, those that deal with the [charts](https://github.com/helm/charts) repository, testing charts, the [hub](https://github.com/helm/hub), etc.
+
+The charts maintainers are documented in the [OWNERS](https://github.com/helm/charts/blob/master/OWNERS) file in the root of the charts repository. They can be contacted privately at kubernetes-charts-leads@googlegroups.com.
+
+## Monocular
+
+[Monocular](https://github.com/helm/monocular) is a web application to present charts that are in chart repositories. It us used to power the Helm Hub. The maintainers are listed in the [OWNERS](https://github.com/helm/monocular/blob/master/OWNERS) file in the root of the project.
+
+## Website
+
+The [Helm website](https://helm.sh) has its own team and [repository](https://github.com/helm/helm-www). It is currently maintained by [flynnduism](https://github.com/flynnduism) with some help from the Org Maintainers.
+
+## Chartmuseum
+
+[Chartmuseum](https://github.com/helm/chartmuseum) is a Helm chart repository. It is currently maintained by [jdolitsky](https://github.com/jdolitsky) with some help from the Org Maintainers.


### PR DESCRIPTION
For the two projects that do not have documented lists of teams there are now open issues to add them.

This is the output of an action item I took in one of the Helm Developer Weekly calls.