### PR TITLE
Removed Justin Scott from security process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,6 @@ Name               | Key URL                                              | Fing
 ------------------ | ---------------------------------------------------- | -----------
 Adam Reese         | [link](https://keybase.io/adamreese/pgp_keys.asc)    | 49D0 9C86 C3DC 8DA3 F0A0 7622 1EF6 1234 7F8A 9958
 Adnan Abdulhussein | [link](https://keybase.io/prydonius/pgp_keys.asc)    | 5111 DA73 DF12 D8E8 12CA 462F 2CDB BFBB 37AE 822A
-Justin Scott       | [link](https://keybase.io/jascott1/pgp_keys.asc)     | 0246 9D6A 9531 A14F E405 E4A4 3C36 16B8 9FBB 1F50
 Matt Butcher       | [link](https://keybase.io/technosophos/pgp_keys.asc) | ABA2 5295 98F6 626C 420D 335B 62F4 9E74 7D91 1B60
 Matt Farina        | [link](https://keybase.io/mattfarina/pgp_keys.asc)   | 672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E
 Matt Fisher        | [link](https://keybase.io/bacongobbler/pgp_keys.asc) | 967F 8AC5 E221 6F9F 4FD2 70AD 92AA 783C BAAE 8E3B


### PR DESCRIPTION
Justing has moved to emeritus status and is no longer actively
maintaining Helm. Verified with him prior to removal.