### PR TITLE
Fixed location of helm logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ issues, mailing lists, meetings, conferences, etc.
 
 ## Assets
 
-- Helm logos are located at [cncf/artwork](https://github.com/cncf/artwork/blob/master/examples/incubating.md#helm-logos)
+- Helm logos are located at [cncf/artwork](https://github.com/cncf/artwork/blob/master/examples/graduated.md#helm-logos)
 - Helm website and docs are located at [helm/helm-www](https://github.com/helm/helm-www)
 - Helm brand examples and guidelines: [art](https://github.com/helm/community/tree/master/art)
 - Helm themed presentation template: [slides](https://github.com/helm/community/tree/master/slides)

--- a/art/readme.md
+++ b/art/readme.md
@@ -1,6 +1,6 @@
 ## Logo
 
-The official Helm logo is found at the [CNCF/artwork](https://github.com/cncf/artwork/blob/master/examples/incubating.md#helm-logos) repo.
+The official Helm logo is found at the [CNCF/artwork](https://github.com/cncf/artwork/blob/master/examples/graduated.md#helm-logos) repo.
 
 ![Logo-Tweak-Light](./images/Logo-Tweak-Light.png)
 


### PR DESCRIPTION
Helm logos link wasn't updated once the project moved from incubating to graduated. 