### PR TITLE
HIP 0002: Announced release dates

### DIFF
--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -1,5 +1,5 @@
 ---
-hip: 9999
+hip: 0002
 title: "Pre-defined release dates for Helm"
 authors: [ "Marc Khouzam <marc.khouzam@montreal.ca>" ]
 created: "2020-09-04"
@@ -14,16 +14,16 @@ Have published release dates for Helm major releases, once such a release has en
 
 ## Motivation
 
-Contributors and users/organisations greatly appreciate knowing in advance when the next release will be available.
-It allows contributors to plan their work and organisations to schedule migration plans; it also avoids disappointing delays and provides users with clear timelines for access to bug fixes and features.
+Contributors and users/organizations greatly appreciate knowing in advance when the next release will be available.
+It allows contributors to plan their work and organizations to schedule migration plans; it also provides users with clear timelines for access to bug fixes and features.
 
 ## Rationale
 
 Minor and patch releases for Helm normally occur a couple of times a year.  They therefore lend themselves well to cyclical, pre-defined release dates.
 
-As it is not recommended to use Helm with a version of Kubernetes that is newer than the version Helm was compiled against ([see here][helm-skew]), there is value in aligning the date for Helm minor releases with [Kubernetes releases][kubernetes-dates], which occur every 3 to 4 months.
+As it is not recommended to use Helm with a version of Kubernetes that is newer than the version Helm was compiled against ([see here][helm-skew]), there is value in aligning the date for Helm minor releases with [Kubernetes releases][kubernetes-dates], which state that "X.Y.0 occur 3 to 4 months after X.(Y-1).0".
 
-Helm major releases happen rarely and therefore do not lend themselves to pre-defined, cyclical release dates.  However, once a major release has been defined and has entered the implementation phase, a specific release date should be chosen and announced.
+Helm major releases happen rarely and therefore do not lend themselves to pre-defined, cyclical release dates.  However, upon the availability of the first beta version of a major release, a specific final release date should be chosen and announced.
 
 ## Specification
 
@@ -35,7 +35,7 @@ For minor releases, it is not necessary to aim for dates that are the same every
 
 Extra minor releases can be added to the schedule when needed.  However:
 * An extra minor release should not change a planned minor release date, unless the planned release is less than 7 days away.  This is to avoid postponing the release of features that are still on-going and planned according to the originally stated release date.
-* Extra minor releases should only be done for important reasons (as per judgment of the maintainers) to avoid increasing the burden on organisations that choose to upgrade at every release.
+* Extra minor releases should only be done for important reasons (as per judgment of the maintainers) to avoid increasing the burden on organizations that choose to upgrade at every release.
 
 ## Security implications
 
@@ -45,6 +45,16 @@ Security releases do not follow any planned dates and should be done as soon as 
 
 * When a Helm minor release is made, the next minor release number and date should be chosen and announced at the same time.
 * The Helm website should have a page mentioning each planned release and its date.  This page should be updated at each release.
+
+## Reference implementation
+
+Should this proposal be accepted, putting it in place would mean:
+* Selecting the date of the next minor release
+* Documenting the new process and the chosen date on helm.sh under Community with a note in the FAQ section
+* Updating the release check-list to include the step of selecting the next minor release date
+* Communicating the new process to core-maintainers through the mailing list
+* Publishing a blog to inform the community of this new process
+* Making a very strong effort to respect the announced dates
 
 ## Open issues
 

--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -50,13 +50,7 @@ Security releases do not follow any planned dates and should be done as soon as 
 
 A reference implementation for this proposal to be accepted would entail:
 * Proposing a date of the next minor release
-* Posting a PR to helm-www documenting the new process and the chosen date
-* Posting a PR to helm-www updating the release check-list to include the step of selecting the next minor release date and publishing it
-
-## Open issues
-
-* This HIP proposes that for minor releases, only the date of the next release will be announced.  We could instead have fixed dates such as: "The first Wednesday of February, June and October".  What approach is preferred?
-* How many previous versions of Helm receive patch releases? If more than one, should those patch releases be on the same date?
+* Posting a PR to helm-www documenting the chosen date and updating the release check-list as per the new process
 
 [kubernetes-dates]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#minor-version-scheme-and-timeline
 [helm-skew]: https://helm.sh/docs/topics/version_skew/#supported-version-skew

--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -27,7 +27,7 @@ Helm major releases happen rarely and therefore do not lend themselves to pre-de
 
 ## Specification
 
-Patch releases should be done once a month on the second Wednesday of each month.
+Patch releases should be done once a month on the second Wednesday of each month (assuming there are changes since the last release). A patch release to fix a high priority regression or security issue does not have to follow this schedule, but it is highly desirable that it is released on a Wednesday if possible.
 
 For minor releases, it is not necessary to aim for dates that are the same every year.  Instead, the following is proposed:
 * Once a Helm minor release is made, the release date of the next minor release must be announced.
@@ -51,7 +51,7 @@ Security releases do not follow any planned dates and should be done as soon as 
 A reference implementation for this proposal to be accepted would entail:
 * Proposing a date of the next minor release
 * Posting a PR to helm-www documenting the new process and the chosen date
-* Posting a PR to helm-www updating the release check-list to include the step of selecting the next minor release date and plublishing it
+* Posting a PR to helm-www updating the release check-list to include the step of selecting the next minor release date and publishing it
 
 ## Open issues
 

--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -10,7 +10,7 @@ status: "draft"
 ## Abstract
 
 Have well-known cyclical release dates for Helm minor and patch releases.
-Have published release dates for Helm major releases, once such a release has entered the implementation phase.
+Have a published release date for a Helm major release, upon the availability of the first beta release.
 
 ## Motivation
 

--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -48,13 +48,10 @@ Security releases do not follow any planned dates and should be done as soon as 
 
 ## Reference implementation
 
-Should this proposal be accepted, putting it in place would mean:
-* Selecting the date of the next minor release
-* Documenting the new process and the chosen date on helm.sh under Community with a note in the FAQ section
-* Updating the release check-list to include the step of selecting the next minor release date
-* Communicating the new process to core-maintainers through the mailing list
-* Publishing a blog to inform the community of this new process
-* Making a very strong effort to respect the announced dates
+A reference implementation for this proposal to be accepted would entail:
+* Proposing a date of the next minor release
+* Posting a PR to helm-www documenting the new process and the chosen date
+* Posting a PR to helm-www updating the release check-list to include the step of selecting the next minor release date and plublishing it
 
 ## Open issues
 

--- a/hips/hip-9999.md
+++ b/hips/hip-9999.md
@@ -1,0 +1,56 @@
+---
+hip: 9999
+title: "Pre-defined release dates for Helm"
+authors: [ "Marc Khouzam <marc.khouzam@montreal.ca>" ]
+created: "2020-09-04"
+type: "process"
+status: "draft"
+---
+
+## Abstract
+
+Have well-known cyclical release dates for Helm minor and patch releases.
+Have published release dates for Helm major releases, once such a release has entered the implementation phase.
+
+## Motivation
+
+Contributors and users/organisations greatly appreciate knowing in advance when the next release will be available.
+It allows contributors to plan their work and organisations to schedule migration plans; it also avoids disappointing delays and provides users with clear timelines for access to bug fixes and features.
+
+## Rationale
+
+Minor and patch releases for Helm normally occur a couple of times a year.  They therefore lend themselves well to cyclical, pre-defined release dates.
+
+As it is not recommended to use Helm with a version of Kubernetes that is newer than the version Helm was compiled against ([see here][helm-skew]), there is value in aligning the date for Helm minor releases with [Kubernetes releases][kubernetes-dates], which occur every 3 to 4 months.
+
+Helm major releases happen rarely and therefore do not lend themselves to pre-defined, cyclical release dates.  However, once a major release has been defined and has entered the implementation phase, a specific release date should be chosen and announced.
+
+## Specification
+
+Patch releases should be done once a month on the second Wednesday of each month.
+
+For minor releases, it is not necessary to aim for dates that are the same every year.  Instead, the following is proposed:
+* Once a Helm minor release is made, the release date of the next minor release must be announced.
+* To align with Kubernetes releases, a 4-month minor release cadence should be adopted (so at least 3 minor releases of Helm per year)
+
+Extra minor releases can be added to the schedule when needed.  However:
+* An extra minor release should not change a planned minor release date, unless the planned release is less than 7 days away.  This is to avoid postponing the release of features that are still on-going and planned according to the originally stated release date.
+* Extra minor releases should only be done for important reasons (as per judgment of the maintainers) to avoid increasing the burden on organisations that choose to upgrade at every release.
+
+## Security implications
+
+Security releases do not follow any planned dates and should be done as soon as required.
+
+## How to teach this
+
+* When a Helm minor release is made, the next minor release number and date should be chosen and announced at the same time.
+* The Helm website should have a page mentioning each planned release and its date.  This page should be updated at each release.
+
+## Open issues
+
+* This HIP proposes that for minor releases, only the date of the next release will be announced.  We could instead have fixed dates such as: "The first Wednesday of February, June and October".  What approach is preferred?
+* How many previous versions of Helm receive patch releases? If more than one, should those patch releases be on the same date?
+
+[kubernetes-dates]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#minor-version-scheme-and-timeline
+[helm-skew]: https://helm.sh/docs/topics/version_skew/#supported-version-skew
+


### PR DESCRIPTION
Replaces #141 

The idea is to have a well-known release cadence for the helm minor releases.

In my experience contributors and users greatly appreciate knowing in advance when the next release will be available.
It allows contributors to plan their work, avoids disappointing delays and provides users with clear timelines for access to bug fixes and features.

Please see details in the HIP document, which can be read nicely formatted here: https://github.com/VilledeMontreal/community/blob/feat/fixedDates/hips/hip-9999.md
