### PR TITLE
Add requirement for reference implementation of HIP 0002

### DIFF
--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -45,12 +45,22 @@ Security releases do not follow any planned dates and should be done as soon as 
 
 * When a Helm minor release is made, the next minor release number and date should be chosen and announced at the same time.
 * The Helm website should have a page mentioning each planned release and its date.  This page should be updated at each release.
+* The Helm website should have a page describing the process for release dates put forth in this HIP
 
 ## Reference implementation
 
 A reference implementation for this proposal to be accepted would entail:
 * Proposing a date of the next minor release
-* Posting a PR to helm-www documenting the chosen date and updating the release check-list as per the new process
+* Posting a PR to helm-www which:
+    * documents the next release date
+    * updates the release check-list as per the new process
+    * creates a page to document the details of this HIP for users
+* Creating a public online calendar so that maintainers can get release reminders and consumers can see the Helm release dates.  The calendar shall contain:
+    * monthly patch release dates
+    * the next minor release date (or major release date if applicable)
+    * dates when RCs must be created
+    * it may be interesting to include kubernetes release dates if available
+* A link to the release calendar shall be added to helm-www
 
 [kubernetes-dates]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#minor-version-scheme-and-timeline
 [helm-skew]: https://helm.sh/docs/topics/version_skew/#supported-version-skew

--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -26,9 +26,18 @@ As it is not recommended to use Helm with a version of Kubernetes that is newer 
 Helm major releases happen rarely and therefore do not lend themselves to pre-defined, cyclical release dates.  However, upon the availability of the first beta version of a major release, a specific final release date should be chosen and announced.
 
 ## Specification
-
+### Patch releases
 Patch releases should be done once a month on the second Wednesday of each month (assuming there are changes since the last release). A patch release to fix a high priority regression or security issue does not have to follow this schedule, but it is highly desirable that it is released on a Wednesday if possible.
 
+#### Cancelling a patch release
+
+A patch release should be cancelled:
+- if it falls within one week before the first release candidate (RC1) of an upcoming minor release
+- if it falls within four weeks following a minor release
+
+As an example, if Helm 3.9.0-rc.1 is scheduled for January 7th, 2022, the expectation is that no patch releases will be cut for Helm 3.8.x after December 31st, 2021.  Similarly, if Helm 3.9.0 is released on January 16th, 2022, the expectation is that the 3.9.1 patch release will not be cut before February 13th, 2022.
+
+### Minor releases
 For minor releases, it is not necessary to aim for dates that are the same every year.  Instead, the following is proposed:
 * Once a Helm minor release is made, the release date of the next minor release must be announced.
 * To align with Kubernetes releases, a 4-month minor release cadence should be adopted (so at least 3 minor releases of Helm per year)


### PR DESCRIPTION
Thinking about  HIP 0002 and published release dates, I realized we also need a page to describe to the community how we will handle dates, alike Kubernetes page: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#minor-version-scheme-and-timeline

This commit updates the HIP to include this aspect.

It also fixes #160 