### PR TITLE
Add quotes to avoid octal interpretation

### DIFF
--- a/hips/hip-0001.md
+++ b/hips/hip-0001.md
@@ -1,5 +1,5 @@
 ---
-hip: 1
+hip: "0001"
 title: "Writing a HIP"
 authors: [ "Matthew Fisher <matt.fisher@microsoft.com>" ]
 created: "2020-08-13"

--- a/hips/hip-0002.md
+++ b/hips/hip-0002.md
@@ -1,5 +1,5 @@
 ---
-hip: 0002
+hip: "0002"
 title: "Pre-defined release dates for Helm"
 authors: [ "Marc Khouzam <marc.khouzam@montreal.ca>" ]
 created: "2020-09-04"

--- a/hips/hip-0003.md
+++ b/hips/hip-0003.md
@@ -1,5 +1,5 @@
 ---
-hip: 0003
+hip: "0003"
 title: "How Projects Join the Helm Organization"
 authors: [ "Matt Butcher <matt.butcher@microsoft.com>" ]
 created: "2020-09-30"

--- a/hips/hip-0006.md
+++ b/hips/hip-0006.md
@@ -1,5 +1,5 @@
 ---
-hip: 0006
+hip: "0006"
 title: "OCI Support"
 authors: [ "Josh Dolitsky" ]
 created: "2020-07-21"

--- a/hips/hip-0008.md
+++ b/hips/hip-0008.md
@@ -1,5 +1,5 @@
 ---
-hip: 0008
+hip: "0008"
 title: "Add descriptions to custom completions"
 authors: [ "Marc Khouzam <marc.khouzam@montreal.ca>" ]
 created: "2020-11-14"


### PR DESCRIPTION
When pushing HIP 0010 I realized the markdown was showing `8` instead.  After some head-scratching, page-reloading and browser-cache-emptying, I realized that the markdown was interpreting the string `0010` as octal because it was not surrounded by quotes.

To align all HIPs, any of which could be used as an example to create a new one, this PR adds quotes to all such strings.

Using decimal digits as was originally done for HIP 1 would also fix the problem; however, since hip 1 named its HIP file `hip-0001.md`, all other hips adopted the full `00xx` format.