### PR TITLE
Moving Vic to Emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,4 +8,7 @@
 * [Matt Fisher](https://github.com/bacongobbler)
 * [Reinhard Nägele](https://github.com/unguiculus)
 * [Scott Rigby](https://github.com/scottrigby)
+
+## Emeritus
+
 * [Vic Iglesias](https://github.com/viglesiasce)


### PR DESCRIPTION
He did so via the public mailing list at
https://lists.cncf.io/g/cncf-helm/message/376