### PR TITLE
Removing Vic from the security team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,6 @@ Matt Butcher       | [link](https://keybase.io/technosophos/pgp_keys.asc) | ABA2
 Matt Farina        | [link](https://keybase.io/mattfarina/pgp_keys.asc)   | 672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E
 Matt Fisher        | [link](https://keybase.io/bacongobbler/pgp_keys.asc) | 967F 8AC5 E221 6F9F 4FD2 70AD 92AA 783C BAAE 8E3B
 Nikhil Manchanda   | [link](https://keybase.io/slicknik/pgp_keys.asc)     | 5674 7211 71F8 CD59 F285 353D 9692 757E BCD3 D66C
-Vic Iglesias       | [link](https://keybase.io/vicnastea/pgp_keys.asc)    | 43A7 994E F6C7 7D7F 147B C152 381B ABCF F47D EAFC
 
 ### When To Send A Report
 


### PR DESCRIPTION
The security team membership requires someone to be an active
maintainer on a project. Vic is not longer an active maintainer
so he is no longer able to be on this team.