### PR TITLE
Add Martin as org maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,6 +3,7 @@
 * [Adam Reese](https://github.com/adamreese)
 * [Adnan Abdulhussein](https://github.com/prydonius)
 * [Josh Dolitsky](https://github.com/jdolitsky)
+* [Martin Hickey](https://github.com/hickeyma)
 * [Matt Butcher](https://github.com/technosophos) (chair)
 * [Matt Farina](https://github.com/mattfarina)
 * [Matt Fisher](https://github.com/bacongobbler)


### PR DESCRIPTION
For review by @technosophos, org chair.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>