### PR TITLE
HIP: Helm Triage Maintainers

### DIFF
--- a/hips/hip-9999.md
+++ b/hips/hip-9999.md
@@ -1,0 +1,71 @@
+---
+hip: 9999
+title: "Helm Triage Maintainers"
+authors: [ "Matthew Fisher <matt.fisher@microsoft.com>" ]
+created: "2021-07-06"
+type: "process"
+status: "draft"
+---
+
+## Abstract
+
+The existing Helm Project Maintainers have identified the need for a new "triage" role. This document lists out the responsibilities of this new role.
+
+## Motivation
+
+Helm Project Maintainers are responsible for activities surrounding the development and release of code, the operation of any services they own (e.g. <https://get.helm.sh>), or the tasks needed to execute their project (e.g., community management, setting up an event booth). Introducing a new "Helm Triage Maintainer" role allows new project maintainers to join the project without the responsibilities of release management, service operation, or event management.
+
+This new role provides three benefits:
+
+1. New triage maintainers can help maintain the project's day-to-day, such as responding to new tickets and review pull requests
+2. Helm project maintainers' burden is reduced, allowing them to carry out higher-level tasks like coordinating software releases, organizing events, and maintaining production services.
+3. Provides an easier on-ramp from community members, to triage maintainers, to project maintainers, to org maintainers.
+
+## Rationale
+
+Project maintainers are looking for new members to join the project. However, community members have expressed in the past that they cannot commit more than a few hours per month to the project. Additionally, some project maintainers are concerned providing newer members the "keys to the castle" prior to a formal vetting process may introduce significant risk to the project's users. A new maintainer may be available to help maintain the project, but it may take several months before trust is established.
+
+## Specification
+
+The new triage maintainer role is allowed to perform certain day-to-day tasks as a maintainer of the project, including:
+
+- attach labels to issues
+- assign issues to milestones
+- receive access to the cncf-helm-core-maintainers mailing list
+- vote on governance-related topics
+- merge pull requests to helm/helm
+
+The following roles and resposibilities are NOT allowed to be performed under this role:
+
+- release new revisions of the Helm Client
+- operate any public-facing services, such as
+   - <https://get.helm.sh>
+   - Mailing lists
+   - Slack channels
+   - The helm/helm Github project
+- organizing official LF events (Helm Summit)
+
+These restrictions can be waived if these responsibilities are performed under direct supervision of a Helm Project Maintainer. For example, if a Helm Triage Maintainer would like to learn the release process, they may "shadow" the Helm Project Maintainer that is assigned as the release engineer. Triage Maintainers may also join the Helm Summit Program Committee to help review CFPs, but cannot be assigned the role of Program Chair.
+
+The same rules about active maintainership applies to triage maintainers. Triage maintainers MUST remain active on the project. If they are unresponsive for > 3 months they will lose maintainership unless a super-majority of the other project maintainers agrees to extend the period to be greater than 3 months.
+
+## Backwards compatibility
+
+Community members may still request for a vote to join as a full project maintainer. This new role provides an additional option to join the project at a lower commitment level.
+
+## Security implications
+
+The role helps protect the Helm Client and its users from new maintainers with malicious intent to de-rail or otherwise "pwn" the project. As Helm is one of the CNCF's most popular projects, a certain level of care and caution should be taken when providing new members access to production services. This new role helps keep the list of maintainers with production system access to a minimum.
+
+## How to teach this
+
+The contents of this HIP will be discussed in the public Helm Dev meeting, which is recorded.
+
+## Rejected ideas
+
+The author considered allowing a triage maintainer to a release engineer, but was rejected as a release engineer needs detailed information about the project's design, intents, and implementation. These tenets are not necessarily required to be a triage maintainer.
+
+## References
+
+- The Helm org's [governance structure](https://github.com/helm/community/tree/main/governance)
+- The Helm org's [team structure](https://github.com/helm/community/blob/main/Teams.md)


### PR DESCRIPTION
Herein describes a new maintainer role for the helm/helm project: Triage Maintainers.