### PR TITLE
Add a list of HIPs to the README

### DIFF
--- a/hips/README.md
+++ b/hips/README.md
@@ -9,3 +9,18 @@ Original proposal source should be written in Markdown format, and the format is
 described in HIP 1. Older proposals were often written in a more mildly
 restricted markdown format and can be found in the
 [archives](archives/README.md).
+
+## Existing HIPs
+
+- [hip-0001: Writing a HIP](hip-0001.md)
+- [hip-0002: Pre-defined release dates for Helm](hip-0002.md)
+- [hip-0003: How Projects Join the Helm Organization](hip-0003.md)
+- [hip-0004: Document backwards-compatibility rules](hip-0004.md)
+- [hip-0005: Helm Org Maintainers and Deprecated Projects](hip-0005.md)
+- [hip-0006: OCI Support](hip-0006.md)
+- [hip-0008: Add descriptions to custom completions](hip-0008.md)
+- [hip-0009: Transitioning Security Team Members on Project Deprecation](hip-0009.md)
+- [hip-0010: Distributed responsibility for picking](hip-0010.md)
+- [hip-0011: CRD Handling in Helm 3](hip-0011.md)
+- [hip-0012: Helm 4 Development Process](hip-0012.md)
+- [hip-0014: Helm Triage Maintainers](hip-0014.md)


### PR DESCRIPTION
HIP file names indicate the HIP number.  Remembering which HIP number
represents which proposal is difficult.  Having the title of the HIP
listed in the README should make finding the correct HIP easier.

The disadvantage is of course that this list must be maintained.