### PR TITLE
remove "receive access to helm-core-maintainers" mailing list

### DIFF
--- a/hips/hip-0014.md
+++ b/hips/hip-0014.md
@@ -31,7 +31,6 @@ The new triage maintainer role is allowed to perform certain day-to-day tasks as
 
 - attach labels to issues
 - assign issues to milestones
-- receive access to the cncf-helm-core-maintainers mailing list
 - review and approve pull requests
 - nominate new triage maintainers
 - nominate new core maintainers
@@ -49,6 +48,7 @@ The following roles and responsibilities are NOT allowed to be performed under t
 - vote on governance-related topics (including membership votes)
 - become a member of the security team
 - receive access to the helm_project Keybase team
+- receive access to the cncf-helm-core-maintainers mailing list
 
 These restrictions can be waived if these responsibilities are performed under direct supervision of a Helm Project Maintainer. For example, if a Helm Triage Maintainer would like to learn the release process, they may "shadow" the Helm Project Maintainer that is assigned as the release engineer. Triage Maintainers may also join the Helm Summit Program Committee to help review CFPs, but cannot be assigned the role of Program Chair.
 


### PR DESCRIPTION
As triage maintainers do not have voting rights, they cannot join the core maintainers mailing list, as that is where all voting occurs.

This was overlooked after we concluded a discussion in https://github.com/helm/community/pull/199#discussion_r686914309. This was discovered during the onboarding process of a new triage maintainer.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>