### PR TITLE
Clarifying voting location

### DIFF
--- a/governance/governance.md
+++ b/governance/governance.md
@@ -70,7 +70,7 @@ Changes to maintainers use the following:
 
 * A maintainer may step down by emailing the [Helm mailing list](https://lists.cncf.io/g/cncf-helm)
 * Maintainers MUST remain active. If they are unresponsive for > 3 months they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months
-* New maintainers can be added to a project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers
+* New maintainers can be added to a project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers. While nomination will happen on the public [Helm mailing list](https://lists.cncf.io/g/cncf-helm), voting will happen on the private maintainer list.
 * When a project has no maintainers the Helm org maintainers become responsible for it and may archive the project or find new maintainers
 
 ## Decision Making at the Helm org level


### PR DESCRIPTION
Per the discussion in the Sept 30th 2021 Helm dev call, I'm proposing a governance update to clarify the voting location. I was going to add it to https://github.com/helm/community/pull/210 but the topic is different enough that I think it needs its own PR.

CC @scottrigby in case the desired scope is greater than this limited scope of the update.

We need 2/3 of org maintainers to upvote this PR if we want to merge it.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>