### PR TITLE
Per the conclusion of the vote on Jan 10, add Karen Chu

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,7 @@
 
 * [Adam Reese](https://github.com/adamreese)
 * [Josh Dolitsky](https://github.com/jdolitsky)
+* [Karen Chu](https://github.com/karenhchu)
 * [Martin Hickey](https://github.com/hickeyma)
 * [Matt Butcher](https://github.com/technosophos) (chair)
 * [Matt Farina](https://github.com/mattfarina)


### PR DESCRIPTION
This adds @karenhchu as a Helm org maintainer.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>