### PR TITLE
Adding an exception to back compat

### DIFF
--- a/hips/hip-0004.md
+++ b/hips/hip-0004.md
@@ -35,6 +35,7 @@ The maintainers have agreed that a formal definition of Helm's backwards-compati
 
 The following compatibility rules will apply to helm minor and patch releases:
 * exported Go APIs will remain compatible as per this [article][go-module-comp]
+    * the exception to this rule is where Helm exposes Kubernetes APIs. Kubernetes APIs do not follow semantic versioning so Helm cannot enforce compatibility.
 * CLI commands and flags:
     * commands and flags are case-sensitive
     * commands and flags must not be removed


### PR DESCRIPTION
Exposing Kubernetes APIs is a place where Helm cannot enforce
backwards compatibility. K8s does not follow semantic versioning.
Making this explicit.