### PR TITLE
HIP: Create the ability for pre-install jobs to fail-fast and provide output

### DIFF
--- a/hips/hip-9999.md
+++ b/hips/hip-9999.md
@@ -1,0 +1,243 @@
+---
+hip: 9999
+title: "New annotations for pre-install and pre-upgrade to fail fast and display output"
+authors: [ "Ian Zink <ian@replicated.com>" ]
+created: "2023-01-26"
+type: "feature"
+status: "draft"
+---
+
+## Abstract
+
+This proposes two new annotations for hooks specific to jobs. One that will cause install, upgrade, or test hooks to block and fail fast. And a second annotation to indicate that the output from the job should be displayed to the user.
+
+
+## Motivation
+
+The primary motivation for this HIP is the ability to run Preflight checks before a helm chart runs to verify it can successfully install. Preflight checks require a way to run and fail fast and to present that check that failed back to the user.
+
+Often it is important to verify that the kubernetes cluster you are deploying a helm chart into has certain properties. You might need to know that the cluster is of a certain version to use various APIs. You might need to know that it has ingress available, a certain amount of ephemeral storage, memory, or CPUs available. You might want to validate the the service key they provided was correct or that that database they entered is reachable. Letting a chart deploy and then finding debugging to see why it failed is a poor user experience. These things can all be done with preflight checks enabled by the hooks proposed in this HIP.
+
+In general, allowing chart developers to run jobs and present that feedback directly to the users could also open up additional use cases beyond just the preflight use case that motivated this HIP.
+
+
+## Rationale
+
+There are other ways that this could be implemented. For example, we could have a separate preflight hook type. However, this new hook type wouldn't be handled at all by previous versions of helm. With this design, the new hooks will degrade into timeout errors instead of continuing to the install phase.
+
+Another strategy could be for helm to include Troubleshoot.sh as a dependent library, but this could result in too tight of a coupling between the projects and lower overall flexibility and adaptability. 
+
+
+## Specification
+
+Templates could include the following annotations on Batch Jobs:
+    
+```yaml
+        "helm.sh/hook": pre-install, pre-upgrade
+        "helm.sh/hook-fail-fast": "true"
+        "helm.sh/show-output": "true"
+```
+
+`helm.sh/hook-fail-fast` would indicate that helm should wait for this job to complete and if it fails should immediately exit the install process.
+`helm.sh/show-output` would indicate that helm should display the output of the job to the user.
+
+Additionally a new user flag should be created `--ignore-fail-fast` that would ignore the results of the job and continue with the install process.
+
+## Backwards compatibility
+
+As helm charts added new fail-fast hooks, old versions of helm would process them as if they were normal hooks. If `--wait-for-jobs` was set, they would timeout and fail. If it was not set, they would continue on to the next hook.
+
+## Security implications
+
+As jobs can already arbitrary code, this HIP does not introduce any new security implications -- only the ability to fail fast and display output.
+
+Potentially the preflight checks could check for security misconfigurations that could enhance the security of the cluster.
+
+## How to teach this
+
+For one an example template would be provided showing how to use the new feature with Troubleshoot.sh to provide preflight checks.
+
+## Reference implementation
+
+The `safe-install` plugin (link in references) demonstrates what running preflights could look like, but not in the fashion implemented in this HIP.
+
+## Rejected ideas
+N/A
+
+## Open issues
+N/A
+
+## References
+
+[Troubleshoot.sh](https://troubleshoot.sh/) - the tool that is the motivation for this HIP. 
+
+[safe-install plugin](https://github.com/z4ce/helm-safe-install) - Plugin that provides a similiar experience to what I hope this HIP will provide natively.
+
+# Reference - Examples Usage
+
+## Example using `false`
+
+Template:
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"-false-job
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-fail-fast": "true"
+    "helm.sh/show-output": "true"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: post-install-job
+        image: "alpine:3.3"
+        command: ["false"]
+```
+
+What it should loook when running:
+```
+$ helm install ./ my-release
+Fail-fast job failed: my-release-false-job
+Job my-release-false-job output: 
+```
+
+## Example using Troubleshoot Preflight Checks
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-preflight-job"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-fail-fast": "true"
+    "helm.sh/show-output": "true"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: preflights
+          configMap:
+            name: "{{ .Release.Name }}-preflight-config"
+      containers:
+      - name: post-install-job
+        image: "replicated/preflight:latest"
+        command: ["preflight", "--interactive=false", "--format json",  "/preflights/preflight.yaml"]
+        volumeMounts:
+        - name: preflights
+          mountPath: /preflights
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: "{{ .Release.Name }}-preflight-config"
+data:
+  preflights.yaml: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Preflight
+    metadata:
+      name: preflight-tutorial
+    spec:
+      collectors:
+        {{ if eq .Values.mariadb.enabled false }}
+        - mysql:
+            collectorName: mysql
+            uri: '{{ .Values.externalDatabase.user }}:{{ .Values.externalDatabase.password }}@tcp({{ .Values.externalDatabase.host }}:{{ .Values.externalDatabase.port }})/{{ .Values.externalDatabase.database }}?tls=false'
+        {{ end }}
+      analyzers:
+        - clusterVersion:
+            outcomes:
+              - fail:
+                  when: "< 1.16.0"
+                  message: The application requires at least Kubernetes 1.16.0, and recommends 1.18.0.
+                  uri: https://kubernetes.io
+              - warn:
+                  when: "< 1.18.0"
+                  message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.18.0 or later.
+                  uri: https://kubernetes.io
+              - pass:
+                  message: Your cluster meets the recommended and required versions of Kubernetes.
+        {{ if eq .Values.mariadb.enabled false }}
+        - mysql:
+            checkName: Must be MySQL 8.x or later
+            collectorName: mysql
+            outcomes:
+              - fail:
+                  when: connected == false
+                  message: Cannot connect to MySQL server
+              - fail:
+                  when: version < 8.x
+                  message: The MySQL server must be at least version 8
+              - pass:
+                  message: The MySQL server is ready
+        {{ end }}
+```
+What it should loook when running:
+```
+$ helm install ./ my-release
+Fail-fast job failed: my-release-preflight-job
+Job my-release-preflight-job output: 
+name: cluster-resources    status: completed       completed: 1    total: 3
+name: mysql/mysql          status: running         completed: 1    total: 3
+name: mysql/mysql          status: completed       completed: 2    total: 3
+name: cluster-info         status: running         completed: 2    total: 3
+{
+  "fail": [
+    {
+      "title": "Required Kubernetes Version",
+      "message": "The application requires at least Kubernetes 1.16.0, and recommends 1.18.0.",
+      "uri": "https://kubernetes.io"
+    },
+    {
+      "title": "Must be MySQL 8.x or later",
+      "message": "Cannot connect to MySQL server"
+    }
+  ]
+}
+name: cluster-info         status: completed       completed: 3    total: 3
+```


### PR DESCRIPTION
This a helm improvement proposal to add new annotations to allow things like preflight checks that need to run as a pre-install hook and cause the install to fail immediately if the job fails.