### PR TITLE
Update Helm Teams with current info and links

### DIFF
--- a/Teams.md
+++ b/Teams.md
@@ -10,32 +10,28 @@ The Org Maintainers are a team defined in the [governance](governance/governance
 
 Repositories under the Helm organization not owned by another team, listed below, are owned by the Org Maintainers.
 
-This team can be directly contacted at the private address of cncf-helm-maintainers@lists.cncf.io. The members of this team are documented in the MAINTAINERS.md file in this repository.
+This team can be directly contacted at the private address of <cncf-helm-maintainers@lists.cncf.io>. The members of this team are documented in the [MAINTAINERS.md](MAINTAINERS.md) file in this repository.
 
 ## Security Team
 
-Helm has a security team and process for handling all security issues. This team, the security process, and the method to contact them (including with the use of encryption) is documented in the SECURITY.md file.
+Helm has a security team and process for handling all security issues. This team, the security process, and the method to contact them (including with the use of encryption) is documented in the [SECURITY.md](SECURITY.md) file in this repository.
 
-## Helm Client
+## Helm Client and SDK
 
-The [Helm client/CLI](https://github.com/helm/helm) has a dedicated team maintaining it. The members of that team are documented in the [OWNERS](https://github.com/helm/helm/blob/main/OWNERS) file in the root of the project.
+The [Helm client/CLI and SDK](https://github.com/helm/helm) has a dedicated team maintaining it. The members of that team are documented in the [OWNERS](https://github.com/helm/helm/blob/main/OWNERS) file in the root of the project.
 
-This team can be directly contacted at the private address of cncf-helm-core-maintainers@lists.cncf.io.
+This team can be directly contacted at the private address of <cncf-helm-core-maintainers@lists.cncf.io>.
 
 ## Charts Maintainers
 
-The Charts Maintainers handle numerous repositories in the Helm GitHub organization. Specifically, those that deal with the [charts](https://github.com/helm/charts) repository, testing charts, the [hub](https://github.com/helm/hub), etc.
+The Charts Maintainers handle numerous repositories in the Helm GitHub organization. Specifically, those that deal with Helm charts such as chart [testing](https://github.com/helm/chart-testing), [releasing](https://github.com/helm/chart-releaser), [automation](https://github.com/orgs/helm/repositories?q=action), and [documentation](https://github.com/helm/charts-repo-actions-demo).
 
-The charts maintainers are documented in the [OWNERS](https://github.com/helm/charts/blob/master/OWNERS) file in the root of the charts repository. They can be contacted privately at kubernetes-charts-leads@googlegroups.com.
-
-## Monocular
-
-[Monocular](https://github.com/helm/monocular) is a web application to present charts that are in chart repositories. It us used to power the Helm Hub. The maintainers are listed in the [OWNERS](https://github.com/helm/monocular/blob/master/OWNERS) file in the root of the project.
+The charts maintainers are documented in the [OWNERS](https://github.com/helm/charts/blob/master/OWNERS) file in the root of the charts repository.
 
 ## Website
 
-The [Helm website](https://helm.sh) has its own team and [repository](https://github.com/helm/helm-www). It is currently maintained by [flynnduism](https://github.com/flynnduism) with some help from the Org Maintainers.
+The [Helm website](https://helm.sh) has its own team and [repository](https://github.com/helm/helm-www). The members of this team are documented in the [OWNERS](https://github.com/helm/helm-www/blob/main/OWNERS) file in that repo.
 
 ## Chartmuseum
 
-[Chartmuseum](https://github.com/helm/chartmuseum) is a Helm chart repository. It is currently maintained by [jdolitsky](https://github.com/jdolitsky) with some help from the Org Maintainers.
+[Chartmuseum](https://github.com/helm/chartmuseum) is a Helm chart repository. The members of this team are documented in the [OWNERS](https://github.com/helm/chartmuseum/blob/main/OWNERS) file in that repo.

--- a/governance/governance.md
+++ b/governance/governance.md
@@ -18,7 +18,7 @@ The services provided include:
 
 ## Maintainers Structure
 
-There are two levels of maintainers for Helm. The Helm org maintainers oversee the overall project and its health. Project maintainers focus on a single codebase, a group of related codebases, a service (e.g., a website), or project to support the other projects (e.g., marketing or community management). For example, the chart maintainers manage the charts repository and a few repositories that support charts.
+There are two levels of maintainers for Helm. The Helm org maintainers oversee the overall project and its health. Project maintainers focus on a single codebase, a group of related codebases, a service (e.g., a website), or project to support the other projects (e.g., marketing or community management). For example, the charts maintainers manage several repositories that support charts testing, releasing, automation, and documentation.
 
 Changes in maintainership have to be announced on the [Helm mailing list](https://lists.cncf.io/g/cncf-helm).
 


### PR DESCRIPTION
- Remove Monocular
- update links to maintainers list files
- update charts maintainers description (no longer a central charts repo, but help with charts tooling and documentation)
- updates wording in governance file to match change to charts maintainers team. No material changes to governance