### PR TITLE
HIP: Helm Vault Integration for Secure Value Retrieval

### DIFF
--- a/hips/hip-0020.md
+++ b/hips/hip-0020.md
@@ -1,0 +1,171 @@
+---
+hip: 0020
+title: "Vault Integration for Helm"
+authors: [ "@Vineet0197 Vineet Aggarwal <vineetaggarwal701@gmail.com>" ]
+created: "2025-02-13"
+type: "feature"
+status: "draft"
+---
+
+## Abstract
+
+This proposal aims to integrate HashiCorp Vault into Helm, allowing users to fetch values.yaml and application-specific properties directly from Vault without requiring an external CLI (vault-cli). This integration will improve security, streamline Helm deployments, and eliminate unnecessary dependencies.
+
+## Motivation
+
+Currently, Helm users rely on external tools like vault-cli to fetch secrets before passing them to Helm as values. This introduces several challenges:
+
+1. Security Risk – Secrets may be exposed as plain text during intermediate processing.
+2. Additional Dependencies – Users must install and configure vault-cli separately.
+3. Complex Workflows – Users must manually fetch secrets and pass them via subprocess calls.
+
+By integrating Vault directly into Helm, we can:
+
+1. Provide secure access to Vault secrets.
+2. Remove the need for external dependencies.
+3. Simplify deployments for organizations using Vault.
+
+## Rationale
+
+Helm already supports multiple getters (http, oci), making it logical to extend this to Vault. This proposal follows Helm’s existing design principles by:
+
+1. Implementing Vault as a getter.Provider, similar to HTTP/OCI.
+2. Keeping the integration optional by using feature flags (--vault-address, --token).
+3. Maintaining security best practices by fetching secrets directly into memory.
+
+## Specification
+
+### **CLI Usage**
+Users can fetch Vault secrets directly using Helm:
+    
+```sh
+    helm install my-release my-chart \
+  --values vault://secret/data/myapp/values \
+  --vault-address https://vault.example.com \
+  --token ${VAULT_TOKEN}
+```
+
+```go
+
+    func All(settings *cli.EnvSettings) Providers {
+        result := Providers{httpProvider, ociProvider}
+
+        // Add Vault Provider if settings contain Vault details
+        if settings.VaultAddress != "" && settings.VaultToken != "" {
+            vaultProvider, _ := NewVaultGetter(settings.VaultAddress, settings.VaultToken)
+            result = append(result, vaultProvider)
+        }
+
+        return result
+    }
+```
+
+## Backwards compatibility
+
+- This feature is optional and does not break existing functionality.
+- If Vault credentials are not provided, Helm operates as usual.
+
+## Security implications
+
+- **Authentication**: Vault token authentication will be required.
+- **Secret Handling**: Secrets are not stored on disk, only in memory.
+
+## How to teach this
+
+Once this feature is integrated into Helm, users can securely fetch values directly from **HashiCorp Vault** while installing or upgrading a Helm release.
+
+### **Using the Vault Integration in Helm CLI**  
+
+Users can provide a Vault secret as a values source using the `vault://` scheme. The required Vault connection details (`vault-address` and `vault-token`) must be specified as CLI flags or environment variables.  
+
+#### **Example Usage**  
+
+```sh
+helm install my-release my-chart \
+  --values vault://secret/data/myapp/values \
+  --vault-address https://vault.example.com \
+  --token ${VAULT_TOKEN}
+```
+
+- vault://secret/data/myapp/values → Fetches the values.yaml directly from Vault.
+- --vault-address → Specifies the Vault server address.
+- --token → Provides authentication to access secrets securely.
+
+## Reference implementation
+
+[Pull Request for Helm](https://github.com/helm/helm/pull/13492) - most upvoted open PR
+
+
+## Rejected ideas
+N/A
+
+## Open issues
+N/A
+
+## References
+
+[Troubleshoot.sh](https://troubleshoot.sh/) - the tool that is the motivation for this HIP. 
+
+[safe-install plugin](https://github.com/z4ce/helm-safe-install) - Plugin that provides a similiar experience to what I hope this HIP will provide natively.
+
+## Reference - Examples Usage
+
+This section provides concrete examples of how users can leverage Helm’s Vault integration to securely fetch values from HashiCorp Vault while installing or upgrading Helm releases.  
+
+### **1. Installing a Helm Chart with Values from Vault**  
+
+Users can install a Helm chart by fetching values directly from **HashiCorp Vault** using the `vault://` scheme:
+
+```sh
+helm install my-release my-chart \
+  --values vault://secret/data/myapp/values \
+  --vault-address https://vault.example.com \
+  --token ${VAULT_TOKEN}
+```
+
+### **2. Using Environment Variables for Vault Authentication**
+
+To avoid passing credentials directly in CLI commands, users can set environment variables:
+
+```sh
+export VAULT_ADDR="https://vault.example.com"
+export VAULT_TOKEN="your-vault-token"
+
+helm install my-release my-chart --values vault://secret/data/myapp/values
+```
+
+### **3. Upgrading a Helm Release with Multiple Values Files from Vault**
+
+If users need to pass multiple values.yaml files stored in Vault, they can do so like this:
+
+```sh
+helm upgrade my-release my-chart \
+  --values vault://secret/data/common-values \
+  --values vault://secret/data/env-specific-values
+```
+
+### **4. Fetching Application-Specific Properties from Vault**
+
+For applications that use .properties files instead of YAML, the integration will also support retrieving such files from Vault:
+
+```sh
+helm install my-app my-chart \
+  --property-file vault://secret/data/myapp/config.properties
+```
+
+### **5. Debugging and Verifying Vault-Integrated Helm Installations**
+
+Users can inspect the merged values before applying the chart:
+
+```sh
+helm template my-release my-chart \
+  --values vault://secret/data/myapp/values
+```
+
+To troubleshoot issues while retrieving values from Vault, users can enable verbose logging:
+
+```sh
+helm install my-release my-chart \
+  --values vault://secret/data/myapp/values \
+  --debug --dry-run
+```


### PR DESCRIPTION
This HIP proposes integrating HashiCorp Vault with Helm to allow secure retrieval of sensitive values directly from Vault during Helm deployments. Currently, Helm users manually fetch secrets using external tools like the Vault CLI before passing them to Helm via --values. This approach introduces security risks and operational overhead.

By adding native Vault support in Helm, users can directly reference Vault secrets in their Helm commands, improving security, automation, and user experience.