### PR TITLE
Document Helm subprojects

### DIFF
--- a/subprojects.yaml
+++ b/subprojects.yaml
@@ -1,0 +1,64 @@
+subprojects:
+- name: Helm Core
+  ownersLink: https://github.com/helm/helm/blob/main/OWNERS
+  repos:
+  - https://github.com/helm/helm
+- name: Helm Org
+  ownersLink: https://github.com/helm/community/blob/main/MAINTAINERS.md
+  repos:
+  - https://github.com/helm/community
+  - https://github.com/helm/pull-sizer
+  - https://github.com/helm/charts-tooling
+  - https://github.com/helm/specs
+  - https://github.com/helm/query-store-quay-logs
+  - https://github.com/helm/github-webhook-dco-labeler
+  - https://github.com/helm/charts-check-pr-title
+  - https://github.com/helm/repo-audit
+  - https://github.com/helm/examples
+- name: Website
+  ownersLink: https://github.com/helm/helm-www/blob/main/OWNERS
+  repos:
+  - https://github.com/helm/helm-www
+- name: Chartmuseum
+  ownersLink: https://github.com/helm/chartmuseum/blob/main/OWNERS
+  repos:
+  - https://github.com/helm/chartmuseum
+- name: Charts tooling
+  owners:
+  - davidkarlsen
+  - mattfarina
+  - scottrigby
+  - sameersbn
+  - unguiculus
+  - paulczar
+  - cpanato
+  - jlegrone
+  - lachie83
+  - maorfr
+  emeritus:
+  - foxish
+  - linki
+  - mgoodness
+  - prydonius
+  - seanknox
+  - viglesiasce
+  repos:
+  - https://github.com/helm/chart-releaser
+  - https://github.com/helm/chart-testing
+  - https://github.com/helm/chart-releaser-action
+  - https://github.com/helm/chart-testing-action
+  - https://github.com/helm/kind-action
+  - https://github.com/helm/charts-repo-actions-demo
+  - https://github.com/helm/homebrew-tap
+- name: get-helm-sh
+  ownersLink: https://github.com/helm/get-helm-sh/blob/main/OWNERS
+  repos:
+  - https://github.com/helm/get-helm-sh
+- name: Acceptance testing
+  ownersLink: https://github.com/helm/acceptance-testing/blob/main/OWNERS
+  repos:
+  - https://github.com/helm/acceptance-testing
+- name: Mapkubeapis plugin
+  ownersLink: https://github.com/helm/helm-mapkubeapis/blob/main/OWNERS
+  repos:
+  - https://github.com/helm/helm-mapkubeapis


### PR DESCRIPTION
Implementing this HIP https://github.com/helm/community/pull/156. @mattfarina PTAL

- This includes all non-archived Helm repos with and without OWNERS/MAINTAINERS files. The ones without are under the Org subproject
- The Charts tooling team usernames are straight from the @helm/charts-maintainers GitHub team, and these repos are known to belong to this team
- For some of these repos we will likely want to add OWNERS files, and perhaps archive some of them, but that can be done separately from this PR (the file can be updated as we update the repos)
- Note the linked HIP is already approved, just waiting for minor changes to be mergeable.

Question: do we want to also list archived repos (and archived teams?) similar to the emeritus maintainers, or only keep the current subprojects/repos?