### PR TITLE
Hip: Schema validation with external dependencies

### DIFF
--- a/hips/hip-9999.md
+++ b/hips/hip-9999.md
@@ -13,7 +13,7 @@ A recent change in Helm's JSON schema validation library (see issue helm/helm#31
 
 ## Motivation
 
-Currently, `values.schema.json` is self-contained, which limits the ability to reuse common schema definitions across multiple charts. For instance, an organization may have a standard definition for a "CPU" or "memory" resource that they want to use in all of their charts. Without the ability to reference external schemas, chart authors are forced to duplicate these definitions in every chart, leading to inconsistencies and maintenance overhead.
+Currently, `values.schema.json` is self-contained, which limits the ability to reuse common schema definitions across multiple charts. For instance, an organization may have a standard definition for a "CPU" or "Liveness Probes" resource that they want to use in all of their charts. Without the ability to reference external schemas, chart authors are forced to duplicate these definitions in every chart, leading to inconsistencies and maintenance overhead.
 
 This proposal solves this problem by providing a mechanism to reference external schemas, making it easier to create and maintain complex charts with shared schema definitions.
 
@@ -21,7 +21,7 @@ This proposal solves this problem by providing a mechanism to reference external
 
 Several approaches were considered:
 
-1.  **Convention-based `schemas` directory**: This approach, while simple, was deemed too implicit and less flexible than an explicit mapping file. Also a folder only for validations doesn't the right approach.
+1.  **Convention-based `schemas` directory**: This approach, while simple, was deemed too implicit and less flexible than an explicit mapping file. Also a folder only for validations doesn't seem the right approach.
 
 2.  **`schema-dependencies.json` file**: This approach was chosen as it provides an explicit, flexible, and decoupled way to manage schema dependencies. It also permits referencing remote definitions.
 


### PR DESCRIPTION
Very early draft for https://github.com/helm/helm/pull/31240#issuecomment-3254589775

I'm curious about the representation like https://blog.artifacthub.io/blog/helm-values-schema-reference/ 

Also my biggest question is, isn't too late to integrate this into Helm V4 ? If we integrate this into Helm v4 in few month, it will probably be behing a command flag, like `--enforce-schema` and by default in Helm v5 ?