### PR TITLE
Moving inactive charts maintainer to emeritus

### DIFF
--- a/maintainer-groups.yaml
+++ b/maintainer-groups.yaml
@@ -21,21 +21,21 @@ maintainerGroups:
   mailingList: cncf-helm-core-maintainers@lists.cncf.io
 - name: Charts
   owners:
-  - lachie83
-  - sameersbn
   - unguiculus
-  - scottrigby
-  - mattfarina
   - davidkarlsen
-  - paulczar
   - cpanato
-  - jlegrone
-  - maorfr
   emeritus:
   - foxish
+  - jlegrone
+  - lachie83
   - linki
+  - maorfr
+  - mattfarina
   - mgoodness
+  - paulczar
   - prydonius
+  - sameersbn
+  - scottrigby
   - seanknox
   - viglesiasce
   repos:


### PR DESCRIPTION
Activity was based on activity on things like conversations, meeting attendance, and devstats. Per the governance, inactive maintainers become emeritus after 3 months of inactivity. Some of these people have been inactive far longer.