### PR TITLE
Update governance voting on new maintainers

### DIFF
--- a/governance/governance.md
+++ b/governance/governance.md
@@ -72,7 +72,8 @@ Changes to maintainers use the following:
 
 * A maintainer may step down by emailing the [Helm mailing list](https://lists.cncf.io/g/cncf-helm)
 * Maintainers MUST remain active. If they are unresponsive for > 3 months they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months
-* New maintainers can be added to a project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers. While nomination will happen on the public [Helm mailing list](https://lists.cncf.io/g/cncf-helm), voting will happen on the private maintainer list.
+* New maintainers can be added to a project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers. Nomination can happen on the public [Helm mailing list](https://lists.cncf.io/g/cncf-helm) with voting on the private maintainer list or it can happen from a pull request to the appropriate record of maintainer for the project (e.g., OWNERS file) with voting happening through approvals on the pull request.
+* While nomination will happen on the public [Helm mailing list](https://lists.cncf.io/g/cncf-helm), voting will happen on the private maintainer list.
 * When a project has no maintainers the Helm org maintainers become responsible for it and may archive the project or find new maintainers
 * When maintainers no longer maintain active projects due to project archival or removal, they become emeritus maintainers unless they join another Helm project as maintainers.
 


### PR DESCRIPTION
This change enables pull requests to be used for adding project maintainers.

Note, this change requires a super majority vote. In our current case that means 4 people voting for approval. Since I made the change that counts as 1 vote.