### PR TITLE
HIP: Validate length of names and labels rather than relying on truncation

### DIFF
--- a/hips/hip-9999.md
+++ b/hips/hip-9999.md
@@ -37,7 +37,7 @@ Most resources in Kubernetes have a 253 character limit.  The 63 character limit
 
 Blanket truncating to 63 characters, as Helm currently encourages, ensures that names supplied to a template will fit within Kubernetes naming limits and not lead to a Helm deployment failure.
 
-Truncation however is in effect an attempt to avoid a configuration error by the chart user as it's hiding the error rather than making the chart user ensure their configuration does not violate Kubernetes naming restrictions.
+Truncation however is in effect an attempt to avoid a configuration error by the chart user as it's hiding the error, rather than making the chart user ensure that their configuration does not violate Kubernetes naming restrictions.
 
 Truncation can also lead to naming collisions when deploying multiple times to the same namespace.
 
@@ -53,7 +53,7 @@ By reducing the need for truncation and trimming logic in chart templates, this 
 
 ## Backwards compatibility
 
-Charts that already truncate names and labels to 63 characters will not be impacted by this change (as they are already ensuring the name/label is not more than 63 characters long by truncating.
+Charts that already truncate names and labels to 63 characters will not be impacted by this change (as they are already ensuring the name/label is not more than 63 characters long by truncating).
 
 ## Security implications
 


### PR DESCRIPTION
This PR introduces a new Helm Improvement Proposal (HIP) to change Helm so that names and labels in templates are validated to be less than 63 characters in length before attempting to apply to Kubernetes, and discourage the current convention of truncating and trimming values.