### PR TITLE
HIP: add H4HIP-0027

### DIFF
--- a/hips/hip-9999.md
+++ b/hips/hip-9999.md
@@ -1,5 +1,5 @@
 ---
-hip: "0027"
+hip: "9999"
 title: "H4HIP: Add Exclude File Option to Helm Lint Command"
 authors: [ "Danilo Patrucco <danilo.patrucco@gmail.com>" ]
 created: "2025-11-24"


### PR DESCRIPTION
Added H4HIP 0027 for the development of the lint ignore feature in helm binaries

Mentioned [here](https://github.com/helm/helm/issues/31568) and [here](https://github.com/helm/helm/issues/31568)