### PR TITLE
Fix indentation for WatchUntilReady method

### DIFF
--- a/hips/hip-0022.md
+++ b/hips/hip-0022.md
@@ -55,7 +55,7 @@ type Waiter interface {
 	Wait(resources ResourceList, timeout time.Duration) error
 	WaitWithJobs(resources ResourceList, timeout time.Duration) error
 	WaitForDelete(resources ResourceList, timeout time.Duration) error
-  WatchUntilReady(resources ResourceList, timeout time.Duration) error
+	WatchUntilReady(resources ResourceList, timeout time.Duration) error
 }
 ```
 


### PR DESCRIPTION
Updated indentation the `WatchUntilReady` method signature in the `Waiter` interface that was not properly formatted in the doc, see https://helm.sh/community/hips/hip-0022/#specification 

<img width="1226" height="462" alt="image" src="https://github.com/user-attachments/assets/f6541e03-89d7-4210-97d2-65f84da0c54e" />
